### PR TITLE
Fixed error and warnings caused by latest numpy 1.16.0

### DIFF
--- a/qml/fchl/fchl_kernel_functions.py
+++ b/qml/fchl/fchl_kernel_functions.py
@@ -28,7 +28,7 @@ from copy import copy
 
 import scipy
 from scipy.special import binom
-from scipy.misc import factorial
+from scipy.special import factorial
 
 def get_gaussian_parameters(tags):
 

--- a/qml/qmlearn/models.py
+++ b/qml/qmlearn/models.py
@@ -345,7 +345,7 @@ class NeuralNetwork(_BaseModel):
         """
 
         if self._representation_type == 'atomic':
-            # Due to how the atomic neural network iś constructed,
+            # Due to how the atomic neural network is constructed,
             # this cannot be done elementwise
             rep = representations.reshape(-1, representations.shape[-1])
             if self._constant_features is None:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ MATH_LINKER_FLAGS = ["-lblas", "-llapack"]
 
 # UNCOMMENT TO FORCE LINKING TO MKL with GNU compilers:
 if mkl_exists(verbose=True):
-    LINKER_FLAGS = ["-lgomp", " -lpthread", "-lm", "-ldl"]
+    LINKER_FLAGS = ["-lgomp", "-lpthread", "-lm", "-ldl"]
     MATH_LINKER_FLAGS = ["-L${MKLROOT}/lib/intel64", "-lmkl_rt"]
 
 # For clang without OpenMP: (i.e. most Apple/mac system)

--- a/test/test_fchl_scalar.py
+++ b/test/test_fchl_scalar.py
@@ -29,7 +29,7 @@ import numpy as np
 import scipy
 from scipy.special import jn
 from scipy.special import binom
-from scipy.misc import factorial
+from scipy.special import factorial
 
 from qml.data import Compound
 


### PR DESCRIPTION
Fixed deprecated scipy.misc to scipy.special and problems with new setuptools handling of "-lpthread" compiler flag. (Had a whitespace by mistake)