### PR TITLE
Add ability to create compounds from file-like objects

### DIFF
--- a/qml/data/compound.py
+++ b/qml/data/compound.py
@@ -357,7 +357,8 @@ class Compound(object):
         self.nuclear_charges = np.empty(self.natoms, dtype=int)
         self.coordinates = np.empty((self.natoms, 3), dtype=float)
 
-        self.name = filename
+        # Give the Compound a name if it is a string
+        self.name = filename if isinstance(filename, string_types) else "Compound"
 
         for i, line in enumerate(lines[2:self.natoms+2]):
             tokens = line.split()

--- a/qml/data/compound.py
+++ b/qml/data/compound.py
@@ -22,6 +22,7 @@
 
 from __future__ import print_function
 
+from six import string_types
 import numpy as np
 import collections
 
@@ -341,13 +342,15 @@ class Compound(object):
     def read_xyz(self, filename):
         """(Re-)initializes the Compound-object with data from an xyz-file.
 
-    :param filename: Input xyz-filename.
-    :type filename: string
-    """
+        :param filename: Input xyz-filename or file-like obejct
+        :type filename: string or file-like object
+        """
 
-        f = open(filename, "r")
-        lines = f.readlines()
-        f.close()
+        if isinstance(filename, string_types):
+            with open(filename, "r") as f:
+                lines = f.readlines()
+        else:
+            lines = filename.readlines()
 
         self.natoms = int(lines[0])
         self.atomtypes = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.13
 scipy
 scikit-learn
 ase
+six

--- a/test/test_compound.py
+++ b/test/test_compound.py
@@ -50,8 +50,16 @@ def test_compound():
     ref_atomtypes = ['C', 'Cl', 'Br', 'H', 'H']
     ref_charges = [ 6, 17, 35,  1 , 1]
 
-    assert compare_lists(ref_atomtypes, c.atomtypes), "Failed parsing atomtypes"
-    assert compare_lists(ref_charges, c.nuclear_charges), "Failed parsing nuclear_charges"
+    assert compare_lists(ref_atomtypes, c2.atomtypes), "Failed parsing atomtypes"
+    assert compare_lists(ref_charges, c2.nuclear_charges), "Failed parsing nuclear_charges"
+
+    # Test extended xyz from a file pointer rather than a filename
+    with open(test_dir + "/data/compound_test.exyz") as fp:
+        c3 = Compound(xyz=fp)
+
+    assert compare_lists(ref_atomtypes, c3.atomtypes), "Failed parsing atomtypes"
+    assert compare_lists(ref_charges, c3.nuclear_charges), "Failed parsing nuclear_charges"
+    
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This is a simple change that allows Compound objects to be created without needing to have a file on disk. It follows a very similar approach to `ase`: The function now changes whether user passes a string and, if not, assumes it to be a file object.

I also added a dependency to six for making Python 2 compatibility easier, and a unit test to cover this new functionality. 