### PR TITLE
Removed all f-code requiring omp_lib from FCHL code

### DIFF
--- a/qml/fchl/ffchl_electric_field_kernels.f90
+++ b/qml/fchl/ffchl_electric_field_kernels.f90
@@ -8,8 +8,6 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
     
     use ffchl_kernels, only: kernel
 
-    use omp_lib, only: omp_get_wtime
-
     implicit none
 
     ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
@@ -121,11 +119,7 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
     ! Max number of neighbors 
     integer :: maxneigh1
     integer :: maxneigh2
-
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
     
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
 
     ! Get max number of neighbors
@@ -229,9 +223,6 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
         enddo
     enddo
 
-    t_start = omp_get_wtime()
-    if (verbose) write (*,"(A)", advance="no") "KERNEL WITH FIELDS"
-    
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj)
     do a = 1, nm1
         ni = n1(a)
@@ -258,12 +249,6 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                    Time = ", t_end - t_start, " s"
-   
-    t_start = omp_get_wtime()
-    if (verbose) write (*,"(A)", advance="no") "KERNEL EF DERIVATIVE 1/2"
-    
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,idx_a,idx_b)
     do a = 1, nm1
         ni = n1(a)
@@ -310,11 +295,6 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
     enddo
     !$OMP END PARALLEL DO
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                Time = ", t_end - t_start, " s"
-
-    t_start = omp_get_wtime()
-    if (verbose) write (*,"(A)", advance="no") "KERNEL EF DERIVATIVE 2/2"
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,idx_a,idx_b)
 
     do a = 1, nm2
@@ -363,12 +343,6 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                Time = ", t_end - t_start, " s"
-
-    t_start = omp_get_wtime()
-    if (verbose) write (*,"(A)", advance="no") "KERNEL EF HESSIAN   "
     
     ! should be zero?
 
@@ -419,9 +393,6 @@ subroutine fget_ef_gaussian_process_kernels_fchl(x1, x2, verbose, f1, f2, n1, n2
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                    Time = ", t_end - t_start, " s"
-
     deallocate(self_scalar1)
     deallocate(self_scalar1_ef)
     deallocate(ksi1)
@@ -443,8 +414,6 @@ subroutine fget_ef_atomic_local_kernels_fchl(x1, x2, verbose, f2, n1, n2, nneigh
         & get_selfscalar, get_ksi, init_cosp_sinp
 
     use ffchl_kernels, only: kernel
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -545,11 +514,7 @@ subroutine fget_ef_atomic_local_kernels_fchl(x1, x2, verbose, f2, n1, n2, nneigh
     ! Max number of neighbors
     integer :: maxneigh1
     integer :: maxneigh2
-
-    ! Variables to calculate time
-    double precision :: t_start, t_end
-
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
+    
     kernels(:,:,:) = 0.0d0
 
     ! Get max number of neighbors
@@ -594,16 +559,7 @@ subroutine fget_ef_atomic_local_kernels_fchl(x1, x2, verbose, f2, n1, n2, nneigh
     self_scalar2 = get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
          & cut_distance, order, pd, ang_norm2,distance_scale, angular_scale, alchemy, verbose)
 
-
     kernels(:,:,:) = 0.0d0
-
-
-    ! write (*,*) nm1, nm2, na1
-    ! write (*,*) size(kernels,dim=1), size(kernels,dim=2), size(kernels,dim=3)
-
-
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
 
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(ni,nj,idx1,s12)
     do a = 1, nm1
@@ -634,9 +590,6 @@ subroutine fget_ef_atomic_local_kernels_fchl(x1, x2, verbose, f2, n1, n2, nneigh
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose)  write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
-
     deallocate(self_scalar1)
     deallocate(self_scalar2)
     deallocate(ksi1)
@@ -657,8 +610,6 @@ subroutine fget_ef_atomic_local_gradient_kernels_fchl(x1, x2, verbose, n1, n2, n
         & get_selfscalar, get_ksi_ef, init_cosp_sinp_ef
 
     use ffchl_kernels, only: kernel
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -761,10 +712,6 @@ subroutine fget_ef_atomic_local_gradient_kernels_fchl(x1, x2, verbose, n1, n2, n
     integer :: maxneigh1
     integer :: maxneigh2
 
-    ! Variables to calculate time
-    double precision :: t_start, t_end
-
-    if (verbose)  write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
 
     ! Get max number of neighbors
@@ -821,9 +768,6 @@ subroutine fget_ef_atomic_local_gradient_kernels_fchl(x1, x2, verbose, n1, n2, n
         enddo
     enddo
 
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL EF DERIVATIVE"
-
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,idx_a,idx_b)
 
     do a = 1, nm1
@@ -872,9 +816,6 @@ subroutine fget_ef_atomic_local_gradient_kernels_fchl(x1, x2, verbose, n1, n2, n
     !$OMP END PARALLEL DO
 
     kernels = kernels / (2 * df)
-
-    t_end = omp_get_wtime()
-    if (verbose)  write (*,"(A,F12.4,A)") "                    Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(self_scalar2_ef)

--- a/qml/fchl/ffchl_module.f90
+++ b/qml/fchl/ffchl_module.f90
@@ -718,8 +718,6 @@ end function scalar_alchemy
 
 function get_ksi(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose) result(ksi)
 
-    use omp_lib, only: omp_get_wtime
-
     implicit none
 
     ! FCHL descriptors for the training set, format (i,maxatoms,5,maxneighbors)
@@ -747,9 +745,6 @@ function get_ksi(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose
     ! Internal counters
     integer :: maxneigh, maxatoms, nm, a, ni, i
     
-    double precision :: t_start, t_end
-
-
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
     nm = size(x, dim=1)
@@ -757,9 +752,6 @@ function get_ksi(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose
     allocate(ksi(nm, maxatoms, maxneigh))
     
     ksi = 0.0d0
-    
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO PRIVATE(ni)
     do a = 1, nm
@@ -770,16 +762,11 @@ function get_ksi(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose
         enddo
     enddo
     !$OMP END PARALLEL do
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                          Time = ", t_end - t_start, " s"
 
 end function get_ksi
 
 
 function get_ksi_displaced(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose) result(ksi)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -807,11 +794,6 @@ function get_ksi_displaced(x, na, nneigh, two_body_power, cut_start, cut_distanc
 
     ! Internal counters
     integer :: maxneigh, maxatoms, nm, a, ni, i, j, pm, xyz, ndisp
-    
-    double precision :: t_start, t_end
-
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY GRADIENT"
-    t_start = omp_get_wtime()
 
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
@@ -838,16 +820,11 @@ function get_ksi_displaced(x, na, nneigh, two_body_power, cut_start, cut_distanc
         enddo
     enddo
     !$OMP END PARALLEL do
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                       Time = ", t_end - t_start, " s"
 
 end function get_ksi_displaced
 
 
 function get_ksi_atomic(x, na, nneigh, two_body_power, cut_start, cut_distance, verbose) result(ksi)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -875,8 +852,6 @@ function get_ksi_atomic(x, na, nneigh, two_body_power, cut_start, cut_distance, 
 
     ! Internal counters
     integer :: maxneigh, nm, i
-    
-    double precision :: t_start, t_end
 
     maxneigh = maxval(nneigh)
     nm = size(x, dim=1)
@@ -884,9 +859,6 @@ function get_ksi_atomic(x, na, nneigh, two_body_power, cut_start, cut_distance, 
     allocate(ksi(na, maxneigh))
 
     ksi = 0.0d0
-    
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO
     do i = 1, na
@@ -895,15 +867,10 @@ function get_ksi_atomic(x, na, nneigh, two_body_power, cut_start, cut_distance, 
     enddo
     !$OMP END PARALLEL do
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                       Time = ", t_end - t_start, " s"
-
 end function get_ksi_atomic
 
 
 subroutine init_cosp_sinp(x, na, nneigh, three_body_power, order, cut_start, cut_distance, cosp, sinp, verbose)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -936,8 +903,6 @@ subroutine init_cosp_sinp(x, na, nneigh, three_body_power, order, cut_start, cut
     integer :: maxneigh, maxatoms, pmax, nm, a, ni, i
 
     double precision, allocatable, dimension(:,:,:,:) :: fourier
-    
-    double precision :: t_start, t_end
 
     
     maxneigh = maxval(nneigh)
@@ -948,9 +913,6 @@ subroutine init_cosp_sinp(x, na, nneigh, three_body_power, order, cut_start, cut
 
     cosp = 0.0d0
     sinp = 0.0d0
-    
-    if (verbose) write (*,"(A)", advance="no") "THREE-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO PRIVATE(ni, fourier) schedule(dynamic)
     do a = 1, nm
@@ -967,15 +929,10 @@ subroutine init_cosp_sinp(x, na, nneigh, three_body_power, order, cut_start, cut
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                        Time = ", t_end - t_start, " s"
-
 end subroutine init_cosp_sinp
 
 
 subroutine init_cosp_sinp_displaced(x, na, nneigh, three_body_power, order, cut_start, cut_distance, cosp, sinp, verbose)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1008,14 +965,8 @@ subroutine init_cosp_sinp_displaced(x, na, nneigh, three_body_power, order, cut_
     integer :: maxneigh, maxatoms, pmax, nm, a, ni, i, j, xyz, pm, xyz_pm
 
     double precision, allocatable, dimension(:,:,:,:) :: fourier
-    
-    double precision :: t_start, t_end
 
     integer :: ndisp
-
-
-    if (verbose) write (*,"(A)", advance="no") "THREE-BODY GRADIENT"
-    t_start = omp_get_wtime()
     
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
@@ -1053,15 +1004,10 @@ subroutine init_cosp_sinp_displaced(x, na, nneigh, three_body_power, order, cut_
     enddo
     !$OMP END PARALLEL do
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                     Time = ", t_end - t_start, " s"
-
 end subroutine init_cosp_sinp_displaced
 
 
 subroutine init_cosp_sinp_atomic(x, na, nneigh, three_body_power, order, cut_start, cut_distance, cosp, sinp, verbose)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1097,8 +1043,6 @@ subroutine init_cosp_sinp_atomic(x, na, nneigh, three_body_power, order, cut_sta
     ! Internal temporary variable
     double precision, allocatable, dimension(:,:,:,:) :: fourier
     
-    double precision :: t_start, t_end
-    
     maxneigh = maxval(nneigh)
     nm = size(x, dim=1)
 
@@ -1106,9 +1050,6 @@ subroutine init_cosp_sinp_atomic(x, na, nneigh, three_body_power, order, cut_sta
 
     cosp = 0.0d0
     sinp = 0.0d0
-    
-    if (verbose) write (*,"(A)", advance="no") "THREE-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO PRIVATE(fourier)
     do i = 1, na
@@ -1122,16 +1063,11 @@ subroutine init_cosp_sinp_atomic(x, na, nneigh, three_body_power, order, cut_sta
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                     Time = ", t_end - t_start, " s"
-
 end subroutine init_cosp_sinp_atomic
 
 
 function get_selfscalar(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
         & cut_distance, order, pd, ang_norm2,distance_scale, angular_scale, alchemy, verbose) result(self_scalar)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1186,11 +1122,6 @@ function get_selfscalar(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
     ! Internal counters
     integer :: a, ni, i
     
-    double precision :: t_start, t_end
-    
-    if (verbose) write (*,"(A)", advance="no") "SELF-SCALAR TERMS"
-    t_start = omp_get_wtime()
-    
     allocate(self_scalar(nm, maxval(na)))
 
     !$OMP PARALLEL DO PRIVATE(ni)
@@ -1207,16 +1138,11 @@ function get_selfscalar(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
     enddo
     !$OMP END PARALLEL DO
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                       Time = ", t_end - t_start, " s"
-
 end function get_selfscalar
 
 
 function get_selfscalar_displaced(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d_width, &
         & cut_distance, order, pd, ang_norm2,distance_scale, angular_scale, alchemy, verbose) result(self_scalar)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1270,11 +1196,6 @@ function get_selfscalar_displaced(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d
 
     ! Internal counters
     integer :: a, ni, i, j, pm, xyz, xyz_pm, ndisp
-    
-    double precision :: t_start, t_end
-    
-    if (verbose) write (*,"(A)", advance="no") "SELF-SCALAR GRADIENT"
-    t_start = omp_get_wtime()
  
     ndisp = size(x, dim=3)
     allocate(self_scalar(nm, 3, ndisp, maxval(na), maxval(na)))
@@ -1305,16 +1226,11 @@ function get_selfscalar_displaced(x, nm, na, nneigh, ksi, sinp, cosp, t_width, d
     enddo
     !$OMP END PARALLEL do
    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                    Time = ", t_end - t_start, " s"
-
 end function get_selfscalar_displaced
 
 
 
 function get_ksi_ef(x, na, nneigh, two_body_power, cut_start, cut_distance, ef_scale, df, verbose) result(ksi)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1349,11 +1265,6 @@ function get_ksi_ef(x, na, nneigh, two_body_power, cut_start, cut_distance, ef_s
 
     ! Electric field
     double precision, dimension(3) :: field
-    
-    double precision :: t_start, t_end
-
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
@@ -1385,15 +1296,10 @@ function get_ksi_ef(x, na, nneigh, two_body_power, cut_start, cut_distance, ef_s
     enddo
     !$OMP END PARALLEL do
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                          Time = ", t_end - t_start, " s"
-
 end function get_ksi_ef
 
 
 function get_ksi_ef_field(x, na, nneigh, two_body_power, cut_start, cut_distance, fields, ef_scale, verbose) result(ksi)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1425,15 +1331,10 @@ function get_ksi_ef_field(x, na, nneigh, two_body_power, cut_start, cut_distance
     ! Internal counters
     integer :: maxneigh, maxatoms, nm, a, ni, i
     
-    double precision :: t_start, t_end
-    
     double precision, intent(in) :: ef_scale
     
     ! Electric field displacement
     ! double precision, intent(in) :: df
-
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
@@ -1456,15 +1357,10 @@ function get_ksi_ef_field(x, na, nneigh, two_body_power, cut_start, cut_distance
     enddo
     !$OMP END PARALLEL do
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                          Time = ", t_end - t_start, " s"
-
 end function get_ksi_ef_field
 
 subroutine init_cosp_sinp_ef(x, na, nneigh, three_body_power, order, cut_start, cut_distance, &
        & cosp, sinp, ef_scale, df, verbose)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1502,16 +1398,11 @@ subroutine init_cosp_sinp_ef(x, na, nneigh, three_body_power, order, cut_start, 
 
     double precision, allocatable, dimension(:,:,:,:) :: fourier
     
-    double precision :: t_start, t_end
-    
     ! Internal counters
     integer :: xyz, pm
 
     ! Electric field
     double precision, dimension(3) :: field
-    
-    if (verbose) write (*,"(A)", advance="no") "THREE-BODY TERMS"
-    t_start = omp_get_wtime()
     
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
@@ -1545,16 +1436,11 @@ subroutine init_cosp_sinp_ef(x, na, nneigh, three_body_power, order, cut_start, 
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                        Time = ", t_end - t_start, " s"
-
 end subroutine init_cosp_sinp_ef
 
 
 subroutine init_cosp_sinp_ef_field(x, na, nneigh, three_body_power, &
         & order, cut_start, cut_distance, cosp, sinp, fields, ef_scale, verbose)
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -1595,11 +1481,6 @@ subroutine init_cosp_sinp_ef_field(x, na, nneigh, three_body_power, &
 
     double precision, allocatable, dimension(:,:,:,:) :: fourier
     
-    double precision :: t_start, t_end
-
-    if (verbose) write (*,"(A)", advance="no") "THREE-BODY TERMS"
-    t_start = omp_get_wtime()
-    
     maxneigh = maxval(nneigh)
     maxatoms = maxval(na)
     nm = size(x, dim=1)
@@ -1625,9 +1506,6 @@ subroutine init_cosp_sinp_ef_field(x, na, nneigh, three_body_power, &
 
     enddo
     !$OMP END PARALLEL DO
-
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                        Time = ", t_end - t_start, " s"
 
 end subroutine init_cosp_sinp_ef_field
 

--- a/qml/fchl/ffchl_scalar_kernels.f90
+++ b/qml/fchl/ffchl_scalar_kernels.f90
@@ -7,8 +7,6 @@ subroutine fget_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, nm1, nm2
     
     use ffchl_kernels, only: kernel
 
-    use omp_lib, only: omp_get_wtime
-
     implicit none
 
     ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
@@ -99,11 +97,7 @@ subroutine fget_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, nm1, nm2
     ! Max number of neighbors 
     integer :: maxneigh1
     integer :: maxneigh2
-
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
     
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
 
     ! Get max number of neighbors
@@ -144,9 +138,6 @@ subroutine fget_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, nm1, nm2
     ! Pre-calculate self-scalar terms 
     self_scalar2 = get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
          & cut_distance, order, pd, ang_norm2,distance_scale, angular_scale, alchemy, verbose)
-
-    t_start = omp_get_wtime()
-    if (verbose) write (*,"(A)", advance="no") "KERNEL"
     
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj)
     do b = 1, nm2
@@ -174,9 +165,6 @@ subroutine fget_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, nm1, nm2
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(self_scalar2)
@@ -198,8 +186,6 @@ subroutine fget_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsigmas, &
     use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp, get_selfscalar
     
     use ffchl_kernels, only: kernel
-
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -261,13 +247,10 @@ subroutine fget_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsigmas, &
     integer :: pmax1
     ! integer :: nneighi
 
-    double precision :: t_start, t_end
-
     double precision :: ang_norm2
 
     integer :: maxneigh1
     
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
 
     ang_norm2 = get_angular_norm2(t_width)
@@ -285,9 +268,6 @@ subroutine fget_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsigmas, &
 
     self_scalar1 = get_selfscalar(x1, nm1, n1, nneigh1, ksi1, sinp1, cosp1, t_width, d_width, &
          & cut_distance, order, pd, ang_norm2,distance_scale, angular_scale, alchemy, verbose)
-
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
 
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj)
     do b = 1, nm1
@@ -317,9 +297,6 @@ subroutine fget_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsigmas, &
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(ksi1)
@@ -336,8 +313,7 @@ subroutine fget_global_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsi
 
     use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp
     use ffchl_kernels, only: kernel
-    use omp_lib, only: omp_get_wtime
-
+    
     implicit none
 
     ! FCHL descriptors for the training set, format (i,j_1,5,m_1)
@@ -401,9 +377,6 @@ subroutine fget_global_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsi
 
     double precision :: mol_dist
 
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
-
     integer :: maxneigh1
 
     maxneigh1 = maxval(nneigh1)
@@ -423,9 +396,6 @@ subroutine fget_global_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsi
     allocate(self_scalar1(nm1))
 
     self_scalar1 = 0.0d0
-   
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO PRIVATE(ni) REDUCTION(+:self_scalar1)
     do a = 1, nm1
@@ -444,14 +414,7 @@ subroutine fget_global_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsi
     enddo
     !$OMP END PARALLEL DO
 
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                          Time = ", t_end - t_start, " s"
-
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
-    
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
 
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,mol_dist)
     do b = 1, nm1
@@ -484,9 +447,6 @@ subroutine fget_global_symmetric_kernels_fchl(x1, verbose, n1, nneigh1, nm1, nsi
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(ksi1)
@@ -504,7 +464,6 @@ subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
 
     use ffchl_module, only: scalar, get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp
     use ffchl_kernels, only: kernel
-    use omp_lib, only: omp_get_wtime
 
     implicit none
 
@@ -580,9 +539,6 @@ subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
 
     double precision :: mol_dist
 
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
-
     integer :: maxneigh1
     integer :: maxneigh2
 
@@ -617,10 +573,6 @@ subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
 
     self_scalar1 = 0.0d0
     self_scalar2 = 0.0d0
-    
-    
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO PRIVATE(ni) REDUCTION(+:self_scalar1)
     do a = 1, nm1
@@ -638,13 +590,6 @@ subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                          Time = ", t_end - t_start, " s"
-    
-    
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
 
     !$OMP PARALLEL DO PRIVATE(ni) REDUCTION(+:self_scalar2)
     do a = 1, nm2
@@ -662,15 +607,8 @@ subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
     enddo
     !$OMP END PARALLEL DO
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                          Time = ", t_end - t_start, " s"
-
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
     
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
-
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12,ni,nj,mol_dist)
     do b = 1, nm2
         nj = n2(b)
@@ -699,9 +637,6 @@ subroutine fget_global_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nneigh2, &
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(self_scalar2)
@@ -726,8 +661,6 @@ subroutine fget_atomic_kernels_fchl(x1, x2, verbose, nneigh1, nneigh2, &
     
     use ffchl_kernels, only: kernel
     
-    use omp_lib, only: omp_get_wtime
-
     implicit none
 
     ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
@@ -791,9 +724,6 @@ subroutine fget_atomic_kernels_fchl(x1, x2, verbose, nneigh1, nneigh2, &
     integer :: pmax1
     integer :: pmax2
     double precision :: ang_norm2
-
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
     
     integer :: maxneigh1
     integer :: maxneigh2
@@ -850,11 +780,7 @@ subroutine fget_atomic_kernels_fchl(x1, x2, verbose, nneigh1, nneigh2, &
     enddo
     !$OMP END PARALLEL DO
 
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
-    
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
 
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12)
     do i = 1, na1
@@ -873,9 +799,6 @@ subroutine fget_atomic_kernels_fchl(x1, x2, verbose, nneigh1, nneigh2, &
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(self_scalar2)
@@ -898,8 +821,6 @@ subroutine fget_atomic_symmetric_kernels_fchl(x1, verbose, nneigh1, na1, nsigmas
         & get_pmax_atomic, get_ksi_atomic, init_cosp_sinp_atomic
     use ffchl_kernels, only: kernel
     
-    use omp_lib, only: omp_get_wtime
-
     implicit none
 
     ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
@@ -956,9 +877,6 @@ subroutine fget_atomic_symmetric_kernels_fchl(x1, verbose, nneigh1, na1, nsigmas
     integer :: pmax1
     double precision :: ang_norm2
 
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
-
     integer :: maxneigh1
 
     maxneigh1 = maxval(nneigh1)
@@ -979,9 +897,6 @@ subroutine fget_atomic_symmetric_kernels_fchl(x1, verbose, nneigh1, na1, nsigmas
 
     self_scalar1 = 0.0d0
     
-    if (verbose) write (*,"(A)", advance="no") "TWO-BODY TERMS"
-    t_start = omp_get_wtime()
-
     !$OMP PARALLEL DO
     do i = 1, na1
         self_scalar1(i) = scalar(x1(i,:,:), x1(i,:,:), &
@@ -993,15 +908,8 @@ subroutine fget_atomic_symmetric_kernels_fchl(x1, verbose, nneigh1, na1, nsigmas
     enddo
     !$OMP END PARALLEL DO
     
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                       Time = ", t_end - t_start, " s"
-
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
     
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
-
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(s12)
     do i = 1, na1
         do j = i, na1
@@ -1020,9 +928,6 @@ subroutine fget_atomic_symmetric_kernels_fchl(x1, verbose, nneigh1, na1, nsigmas
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(ksi1)
@@ -1042,8 +947,6 @@ subroutine fget_atomic_local_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nnei
         & get_angular_norm2, get_pmax, get_ksi, init_cosp_sinp, get_selfscalar
     use ffchl_kernels, only: kernel
     
-    use omp_lib, only: omp_get_wtime
-
     implicit none
 
     ! fchl descriptors for the training set, format (i,maxatoms,5,maxneighbors)
@@ -1129,9 +1032,6 @@ subroutine fget_atomic_local_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nnei
     integer :: maxneigh1
     integer :: maxneigh2
 
-    ! Variables to calculate time 
-    double precision :: t_start, t_end
-
     maxneigh1 = maxval(nneigh1)
     maxneigh2 = maxval(nneigh2)
 
@@ -1163,11 +1063,7 @@ subroutine fget_atomic_local_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nnei
     self_scalar2 = get_selfscalar(x2, nm2, n2, nneigh2, ksi2, sinp2, cosp2, t_width, d_width, &
          & cut_distance, order, pd, ang_norm2,distance_scale, angular_scale, alchemy, verbose)
 
-    if (verbose) write (*,*) "CLEARING KERNEL MEM"
     kernels(:,:,:) = 0.0d0
-
-    t_start = omp_get_wtime()
-    if (verbose)  write (*,"(A)", advance="no") "KERNEL"
 
     !$OMP PARALLEL DO schedule(dynamic) PRIVATE(ni,nj,idx1,s12)
     do a = 1, nm1
@@ -1197,9 +1093,6 @@ subroutine fget_atomic_local_kernels_fchl(x1, x2, verbose, n1, n2, nneigh1, nnei
         enddo
     enddo
     !$OMP END PARALLEL DO
-    
-    t_end = omp_get_wtime()
-    if (verbose) write (*,"(A,F12.4,A)") "                                  Time = ", t_end - t_start, " s"
 
     deallocate(self_scalar1)
     deallocate(self_scalar2)


### PR DESCRIPTION
Removed timers from FCHL code, in order to remove dependency on lib_omp, in order to preserve MacOS compatibility of the dev branch.