### PR TITLE
Feature enum style kernel types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
  - pip3 install pandas
  - pip3 install scikit-learn
  - pip3 install tensorflow
+ - pip3 install attrs=19.1.0
  - python3 setup.py build
  - python3 setup.py install
  - pip3 install sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
  - pip3 install pandas
  - pip3 install scikit-learn
  - pip3 install tensorflow
- - pip3 install attrs=19.1.0
+ - pip install --upgrade attrs==19.1.0
  - python3 setup.py build
  - python3 setup.py install
  - pip3 install sphinx

--- a/qml/fchl/fchl_kernel_functions.py
+++ b/qml/fchl/fchl_kernel_functions.py
@@ -30,6 +30,9 @@ import scipy
 from scipy.special import binom
 from scipy.special import factorial
 
+from .ffchl_module import ffchl_kernel_types as kt
+
+
 def get_gaussian_parameters(tags):
 
     if tags is None:
@@ -44,7 +47,7 @@ def get_gaussian_parameters(tags):
 
     n_kernels = len(tags["sigma"])
 
-    return 1, parameters, n_kernels
+    return kt.gaussian, parameters, n_kernels
 
 
 def get_linear_parameters(tags):
@@ -59,7 +62,7 @@ def get_linear_parameters(tags):
     
     n_kernels = len(tags["c"])
 
-    return 2, parameters, n_kernels
+    return kt.linear, parameters, n_kernels
 
 
 def get_polynomial_parameters(tags):
@@ -80,7 +83,7 @@ def get_polynomial_parameters(tags):
     assert len(tags["alpha"]) == len(tags["d"])
 
     n_kernels = len(tags["alpha"])
-    return 3, parameters, n_kernels
+    return kt.polynomial, parameters, n_kernels
 
 
 def get_sigmoid_parameters(tags):
@@ -99,7 +102,7 @@ def get_sigmoid_parameters(tags):
     assert len(tags["alpha"]) == len(tags["c"])
     n_kernels = len(tags["alpha"])
 
-    return 4, parameters, n_kernels
+    return kt.sigmoid, parameters, n_kernels
 
 
 def get_multiquadratic_parameters(tags):
@@ -117,7 +120,7 @@ def get_multiquadratic_parameters(tags):
     np.resize(parameters, (1,len(tags["c"])))
     n_kernels = len(tags["c"])
     
-    return 5, parameters, n_kernels
+    return kt.multiquadratic, parameters, n_kernels
 
 
 def get_inverse_multiquadratic_parameters(tags):
@@ -135,7 +138,7 @@ def get_inverse_multiquadratic_parameters(tags):
     np.resize(parameters, (1,len(tags["c"])))
     n_kernels = len(tags["c"])
     
-    return 6, parameters, n_kernels
+    return kt.inv_multiquadratic, parameters, n_kernels
 
 
 def get_bessel_parameters(tags):
@@ -157,7 +160,7 @@ def get_bessel_parameters(tags):
 
     n_kernels = len(tags["sigma"])
 
-    return 7, parameters, n_kernels
+    return kt.bessel, parameters, n_kernels
 
 def get_l2_parameters(tags):
 
@@ -175,7 +178,7 @@ def get_l2_parameters(tags):
     assert len(tags["alpha"]) == len(tags["c"])
     n_kernels = len(tags["alpha"])
 
-    return 8, parameters, n_kernels
+    return kt.l2, parameters, n_kernels
 
 
 def get_matern_parameters(tags):
@@ -204,7 +207,7 @@ def get_matern_parameters(tags):
 
     parameters = parameters.T
 
-    return 9, parameters, n_kernels
+    return kt.matern, parameters, n_kernels
 
 
 def get_cauchy_parameters(tags):
@@ -222,7 +225,8 @@ def get_cauchy_parameters(tags):
     np.resize(parameters, (1,len(tags["sigma"])))
     n_kernels = len(tags["sigma"])
 
-    return 10, parameters, n_kernels
+    return kt.cauchy, parameters, n_kernels
+
 
 def get_polynomial2_parameters(tags):
     
@@ -239,12 +243,13 @@ def get_polynomial2_parameters(tags):
 
     n_kernels = len(tags["coeff"])
     parameters = parameters.T
-    return 11, parameters, n_kernels
+    return kt.polynomial2, parameters, n_kernels
+
 
 def get_kernel_parameters(name, tags):
 
     parameters = None
-    idx = 1
+    idx = kt.gaussian
     n_kernels = 1
    
     if name == "gaussian":

--- a/qml/fchl/ffchl_kernel_types.f90
+++ b/qml/fchl/ffchl_kernel_types.f90
@@ -1,0 +1,19 @@
+module ffchl_kernel_types
+    implicit none
+
+    public
+
+    ! define kernel enums
+    integer, parameter :: GAUSSIAN = 1
+    integer, parameter :: LINEAR = 2
+    integer, parameter :: POLYNOMIAL = 3
+    integer, parameter :: SIGMOID = 4
+    integer, parameter :: MULTIQUADRATIC = 5
+    integer, parameter :: INV_MULTIQUADRATIC = 6
+    integer, parameter :: BESSEL = 7
+    integer, parameter :: L2 = 8
+    integer, parameter :: MATERN = 9
+    integer, parameter :: CAUCHY = 10
+    integer, parameter :: POLYNOMIAL2 = 11
+
+end module ffchl_kernel_types

--- a/qml/fchl/ffchl_kernels.f90
+++ b/qml/fchl/ffchl_kernels.f90
@@ -284,6 +284,8 @@ end subroutine polynomial2_kernel
 
 function kernel(s11, s22, s12, kernel_idx, parameters) result(k)
 
+    use ffchl_kernel_types
+
     implicit none
 
     double precision, intent(in) :: s11
@@ -298,37 +300,37 @@ function kernel(s11, s22, s12, kernel_idx, parameters) result(k)
     n = size(parameters, dim=1)
     allocate(k(n))
 
-    if (kernel_idx == 1) then
+    if (kernel_idx == GAUSSIAN) then
         call gaussian_kernel(s11, s22, s12, parameters, k)
 
-    else if (kernel_idx == 2) then
+    else if (kernel_idx == LINEAR) then
         call linear_kernel(s12, parameters, k)
     
-    else if (kernel_idx == 3) then
+    else if (kernel_idx == POLYNOMIAL) then
         call polynomial_kernel(s12, parameters, k)
 
-    else if (kernel_idx == 4) then
+    else if (kernel_idx == SIGMOID) then
         call sigmoid_kernel(s12, parameters, k)
 
-    else if (kernel_idx == 5) then
+    else if (kernel_idx == MULTIQUADRATIC) then
         call multiquadratic_kernel(s11, s22, s12, parameters, k)
 
-    else if (kernel_idx == 6) then
+    else if (kernel_idx == INV_MULTIQUADRATIC) then
         call inverse_multiquadratic_kernel(s11, s22, s12, parameters, k)
 
-    else if (kernel_idx == 7) then
+    else if (kernel_idx == BESSEL) then
         call bessel_kernel(s12, parameters, k)
     
-    else if (kernel_idx == 8) then
+    else if (kernel_idx == L2) then
         call l2_kernel(s11, s22, s12, parameters, k)
     
-    else if (kernel_idx == 9) then
+    else if (kernel_idx == MATERN) then
         call matern_kernel(s11, s22, s12, parameters, k)
     
-    else if (kernel_idx == 10) then
+    else if (kernel_idx == CAUCHY) then
         call cauchy_kernel(s11, s22, s12, parameters, k)
     
-    else if (kernel_idx == 11) then
+    else if (kernel_idx == POLYNOMIAL2) then
         call polynomial2_kernel(s12, parameters, k)
 
     else

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ ext_fgradient_kernels = Extension(name = '.kernels.fgradient_kernels',
 ext_ffchl_module = Extension(name = '.fchl.ffchl_module',
                           sources = [
                               'qml/fchl/ffchl_module.f90',
+                              'qml/fchl/ffchl_kernel_types.f90',
                               'qml/fchl/ffchl_kernels.f90',
                               'qml/fchl/ffchl_scalar_kernels.f90',
                               'qml/fchl/ffchl_force_kernels.f90',

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ def readme():
     with open('README.rst') as f:
         return f.read()
 
+
 def setup_qml():
 
     setup(
@@ -190,6 +191,7 @@ def setup_qml():
               ext_farad_kernels,
         ],
 )
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Introduces an enum-style declaration (not a true enum) for fchl kernels so when adding new kernel types they are declared by their index in **one** place `ffchl_kernel_types` and not by numbers.

Also fixes an incompatibility with `pytest` and `attrs`.