### PR TITLE
Fixes #119

### DIFF
--- a/qml/representations/frepresentations.f90
+++ b/qml/representations/frepresentations.f90
@@ -31,7 +31,7 @@ subroutine get_indices(natoms, nuclear_charges, type1, n, type1_indices)
     integer, intent(in) :: type1
     integer, dimension(:), intent(in) :: nuclear_charges
 
-    integer, intent(out) :: n
+    integer, intent(inout) :: n
     integer, dimension(:), intent(out) :: type1_indices
     integer :: j
 


### PR DESCRIPTION
When declaring a variable as out in fortran the value
is not defined. The function get_indices used the old
value and thus redeclared as inout