### PR TITLE
Add configuration for build time dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+# https://numpy.org/devdocs/reference/distutils_status_migration.html
+# Upper limits of versions for old tooling
+requires = [
+    "setuptools<60.0",
+    "numpy<1.23.0"
+]


### PR DESCRIPTION
Resolves #145.

In accordance with https://peps.python.org/pep-0517/ , the build time dependency NumPy should be specified, as otherwise QML cannot be installed unless NumPy is already installed on the system, which breaks installation in fresh virtual environments.

This change specifies the build time dependency, and so should fix the issue. Once it is released, the following commands should run without error:

```bash
python3 -m venv venv
source venv/bin/activate
pip install qml
```